### PR TITLE
Use correct decoder layer num.

### DIFF
--- a/transformer.py
+++ b/transformer.py
@@ -430,7 +430,7 @@ class Transformer(BaseModelMixin):
     def decoder(self, target, enc_out, input_mask, target_mask, scope='decoder'):
         out = target
         with tf.variable_scope(scope):
-            for i in range(self.num_enc_layers):
+            for i in range(self.num_dec_layers):
                 out = self.decoder_layer(out, enc_out, input_mask, target_mask, f'dec_{i}')
         return out
 


### PR DESCRIPTION
I guess this is a typo or copy-paste error.

Though I have not a lot knowledge about this model. I just thought it doesn't make sense to have ``num_dec_layers`` and not use it.